### PR TITLE
Improve notifications persistence with SQLite

### DIFF
--- a/echonoti/.gitignore
+++ b/echonoti/.gitignore
@@ -58,3 +58,4 @@ yarn-error.log*
 *.env.*.local
 db.json
 src/lib/db.json
+src/lib/notifications.db

--- a/echonoti/.gitignore
+++ b/echonoti/.gitignore
@@ -56,6 +56,5 @@ yarn-error.log*
 .DS_Store
 *.env.local
 *.env.*.local
-db.json
-src/lib/db.json
 src/lib/notifications.db
+src/lib/notifications.db-*

--- a/echonoti/README.md
+++ b/echonoti/README.md
@@ -1,5 +1,73 @@
-# Firebase Studio
+# EchoNoti Progressive Web App
 
-This is a NextJS starter in Firebase Studio.
+EchoNoti is a small PWA used to display notifications from external services. Notifications are stored in a lightweight SQLite database and can be accessed through simple HTTP endpoints.
 
-To get started, take a look at src/app/page.tsx.
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+   The app will be available at `http://localhost:9003` by default.
+
+## REST API
+
+Notifications can be managed via HTTP calls. All endpoints return JSON.
+
+### List notifications
+
+```
+GET /api/notifications
+```
+Returns an array of all notifications ordered by creation date.
+
+### Create a notification
+
+```
+POST /api/notifications
+Content-Type: application/json
+
+{
+  "headline": "System Update",
+  "summary": "Short description",
+  "content": "Full markdown content",
+  "type": "System"
+}
+```
+The response contains the created notification object.
+
+### Get a single notification
+
+```
+GET /api/notifications/{id}
+```
+Returns the notification with the given `id` or `404` if it does not exist.
+
+### Update a notification
+
+```
+PUT /api/notifications/{id}
+Content-Type: application/json
+
+{
+  "headline": "New headline",
+  "read": true,
+  "bookmarked": true
+}
+```
+Only the provided fields are updated. The response contains the updated notification.
+
+### Delete a notification
+
+```
+DELETE /api/notifications/{id}
+```
+Removes the notification. The response will be `{ "success": true }` on success or `404` if the item is not found.
+
+## License
+
+This project is licensed under the MIT License.

--- a/echonoti/package-lock.json
+++ b/echonoti/package-lock.json
@@ -31,6 +31,7 @@
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "better-sqlite3": "^12.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
@@ -53,6 +54,7 @@
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.13",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -4182,6 +4184,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
@@ -4681,6 +4693,20 @@
         }
       ]
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.0.0.tgz",
+      "integrity": "sha512-ElLgwbEth4MHBrDXEqzkE7Hm2+ACw5+KKBhkLArcjJrVFJyOXvzcE/if2dx7/m5pXTc8vqJjsCQUt1AFQY+TTQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -4700,11 +4726,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -4759,7 +4793,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5004,6 +5037,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -5555,6 +5594,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deeks": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/deeks/-/deeks-3.1.0.tgz",
@@ -5563,6 +5617,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/defaults": {
@@ -5636,7 +5699,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5801,7 +5863,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5963,6 +6024,15 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/express": {
       "version": "4.21.2",
@@ -6203,6 +6273,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -6393,6 +6469,12 @@
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -6633,6 +6715,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -7033,7 +7121,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7086,6 +7173,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
@@ -8729,6 +8822,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -8758,6 +8863,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
@@ -8804,6 +8915,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -8898,6 +9015,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -9431,6 +9560,32 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9532,7 +9687,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
       "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -9594,6 +9748,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/react": {
@@ -9786,7 +9955,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -10410,6 +10578,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -10525,7 +10738,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -10631,6 +10843,15 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/stubs": {
@@ -10774,6 +10995,34 @@
       "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/teeny-request": {
@@ -11025,6 +11274,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-fest": {

--- a/echonoti/package.json
+++ b/echonoti/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "better-sqlite3": "^12.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
@@ -57,6 +58,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/echonoti/src/app/api/notifications/[id]/route.ts
+++ b/echonoti/src/app/api/notifications/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { getNotificationById, updateNotification, deleteNotification } from '@/lib/db';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const notification = await getNotificationById(params.id);
+    if (!notification) {
+      return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+    }
+    return NextResponse.json(notification);
+  } catch (error) {
+    console.error('Error retrieving notification:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body = await request.json();
+    const updated = await updateNotification(params.id, body);
+    if (!updated) {
+      return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+    }
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error('Error updating notification:', error);
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const success = await deleteNotification(params.id);
+    if (!success) {
+      return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting notification:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/echonoti/src/app/api/notifications/route.ts
+++ b/echonoti/src/app/api/notifications/route.ts
@@ -1,5 +1,15 @@
 import { NextResponse } from 'next/server';
-import { addNotification } from '@/lib/db';
+import { addNotification, getNotifications } from '@/lib/db';
+
+export async function GET() {
+  try {
+    const notifications = await getNotifications();
+    return NextResponse.json(notifications);
+  } catch (error) {
+    console.error('Error fetching notifications:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
 
 export async function POST(request: Request) {
   try {

--- a/echonoti/src/app/api/notifications/route.ts
+++ b/echonoti/src/app/api/notifications/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
 import { addNotification, getNotifications } from '@/lib/db';
 
 export async function GET() {
@@ -29,6 +30,10 @@ export async function POST(request: Request) {
     };
 
     const newNotification = await addNotification(notificationData);
+
+    // Revalidate the notifications pages to update stale data
+    revalidatePath('/');
+    revalidatePath('/bookmarked');
 
     return NextResponse.json(newNotification, { status: 201 });
   } catch (error) {

--- a/echonoti/src/app/layout.tsx
+++ b/echonoti/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Header } from "@/components/Header";
 import PwaRegistry from "@/components/PwaRegistry";
 import "./globals.css";
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: "EchoNoti",
   description: "Your personal LLM notification hub.",

--- a/echonoti/src/components/NotificationCard.tsx
+++ b/echonoti/src/components/NotificationCard.tsx
@@ -18,6 +18,17 @@ import {
   DialogTrigger,
   DialogFooter,
 } from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -88,18 +99,77 @@ export function NotificationCard({ notification }: { notification: Notification 
           </DialogTrigger>
           
           <div className="absolute top-4 right-4 flex items-center space-x-0">
-            <form action={toggleBookmarkStatus}>
-              <input type="hidden" name="id" value={notification.id} />
-              <Button variant="ghost" size="icon" className="h-8 w-8" type="submit" aria-label={notification.bookmarked ? 'Remove bookmark' : 'Add bookmark'}>
-                <Bookmark className={cn("h-4 w-4", notification.bookmarked && "fill-primary text-primary")} />
-              </Button>
-            </form>
-            <form action={deleteNotification}>
-               <input type="hidden" name="id" value={notification.id} />
-                <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-destructive/10 hover:text-destructive" type="submit" aria-label="Delete notification">
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label={notification.bookmarked ? 'Remove bookmark' : 'Add bookmark'}
+                >
+                  <Bookmark
+                    className={cn(
+                      "h-4 w-4",
+                      notification.bookmarked && "fill-primary text-primary"
+                    )}
+                  />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    {notification.bookmarked
+                      ? 'Remove bookmark?'
+                      : 'Add bookmark?'}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {notification.bookmarked
+                      ? 'This will remove the bookmark from this notification.'
+                      : 'This will bookmark this notification.'}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <form action={toggleBookmarkStatus}>
+                    <input type="hidden" name="id" value={notification.id} />
+                    <AlertDialogAction type="submit">Confirm</AlertDialogAction>
+                  </form>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="Delete notification"
+                >
                   <Trash2 className="h-4 w-4" />
                 </Button>
-            </form>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you sure you want to delete this?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <form action={deleteNotification}>
+                    <input type="hidden" name="id" value={notification.id} />
+                    <AlertDialogAction
+                      type="submit"
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/80"
+                    >
+                      Delete
+                    </AlertDialogAction>
+                  </form>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       </div>
@@ -119,7 +189,7 @@ export function NotificationCard({ notification }: { notification: Notification 
             </ReactMarkdown>
         </div>
         <DialogFooter>
-            <Button onClick={() => setIsOpen(false)}>Close</Button>
+            <Button onClick={() => handleOpenChange(false)}>Close</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/echonoti/src/lib/db.ts
+++ b/echonoti/src/lib/db.ts
@@ -1,105 +1,104 @@
-import type { Notification } from "./types";
-import { randomUUID } from "crypto";
-import { promises as fs } from 'fs';
+import Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
 import path from 'path';
+import type { Notification } from './types';
 
-const dbPath = path.join(process.cwd(), 'src', 'lib', 'db.json');
+const dbPath = path.join(process.cwd(), 'src', 'lib', 'notifications.db');
+const db = new Database(dbPath);
 
-// Initial data if the db.json file doesn't exist
+db.exec(`
+  CREATE TABLE IF NOT EXISTS notifications (
+    id TEXT PRIMARY KEY,
+    headline TEXT NOT NULL,
+    content TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    type TEXT NOT NULL,
+    read INTEGER NOT NULL DEFAULT 0,
+    bookmarked INTEGER NOT NULL DEFAULT 0,
+    createdAt INTEGER NOT NULL
+  );
+`);
+
 const initialNotifications: Notification[] = [
   {
-    id: "1",
-    headline: "System Update v2.1",
-    summary: "A new system update is available. This includes performance improvements and bug fixes.",
-    content: "## System Update v2.1\n\nWe're excited to announce the release of System Update v2.1. This update focuses on improving the stability and performance of the application.\n\n### Key Changes:\n- **Performance:** Optimized data fetching, leading to 20% faster load times.\n- **Bug Fixes:** Resolved an issue where notifications would not sync correctly across devices.\n- **UI:** Minor visual adjustments for a cleaner look.",
-    type: "System",
+    id: '1',
+    headline: 'System Update v2.1',
+    summary: 'A new system update is available. This includes performance improvements and bug fixes.',
+    content: `## System Update v2.1\n\nWe're excited to announce the release of System Update v2.1. This update focuses on improving the stability and performance of the application.\n\n### Key Changes:\n- **Performance:** Optimized data fetching, leading to 20% faster load times.\n- **Bug Fixes:** Resolved an issue where notifications would not sync correctly across devices.\n- **UI:** Minor visual adjustments for a cleaner look.`,
+    type: 'System',
     read: false,
     bookmarked: true,
-    createdAt: new Date(Date.now() - 1000 * 60 * 5), // 5 minutes ago
+    createdAt: new Date(Date.now() - 1000 * 60 * 5),
   },
   {
-    id: "2",
-    headline: "Security Alert: New Login",
+    id: '2',
+    headline: 'Security Alert: New Login',
     summary: "A new device has logged into your account. If this wasn't you, please secure your account immediately.",
-    content: "### Security Alert\n\nA login to your account was just detected from a new device:\n\n- **Device:** Chrome on macOS\n- **Location:** San Francisco, CA (approximate)\n- **Time:** " + new Date(Date.now() - 1000 * 60 * 60 * 2).toLocaleString() + "\n\nIf you do not recognize this activity, please [change your password](/) immediately and review your account security settings.",
-    type: "Security",
+    content: `### Security Alert\n\nA login to your account was just detected from a new device:\n\n- **Device:** Chrome on macOS\n- **Location:** San Francisco, CA (approximate)\n- **Time:** ${new Date(Date.now() - 1000 * 60 * 60 * 2).toLocaleString()}\n\nIf you do not recognize this activity, please [change your password](/) immediately and review your account security settings.`,
+    type: 'Security',
     read: false,
     bookmarked: false,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2), // 2 hours ago
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2),
   },
   {
-    id: "3",
-    headline: "Welcome to LLM Notifier!",
-    summary: "Get started with the platform and learn about its features.",
-    content: "# Welcome!\n\nThis is your new notification center. You can receive updates, alerts, and other information directly from your connected LLM services.\n\nTo add a new notification, you can use our API. For example:\n\n```bash\ncurl -X POST http://localhost:9003/api/notifications \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"headline\": \"Test from curl\",\n  \"summary\": \"This is a test notification.\",\n  \"content\": \"Full content here.\",\n  \"type\": \"API Example\"\n}'\n```",
-    type: "General",
+    id: '3',
+    headline: 'Welcome to LLM Notifier!',
+    summary: 'Get started with the platform and learn about its features.',
+    content: `# Welcome!\n\nThis is your new notification center. You can receive updates, alerts, and other information directly from your connected LLM services.\n\nTo add a new notification, you can use our API. For example:\n\n\`\`\`bash\ncurl -X POST http://localhost:9003/api/notifications \\
+-H "Content-Type: application/json" \\
+-d '{"headline": "Test from curl","summary": "This is a test notification.","content": "Full content here.","type": "API Example"}'\n\`\`\``,
+    type: 'General',
     read: true,
     bookmarked: false,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
   },
 ];
 
-// This will hold the actual data - start empty and load from file
-let notifications: Notification[] = [];
-let isInitialized = false;
+function rowToNotification(row: any): Notification {
+  return {
+    id: row.id,
+    headline: row.headline,
+    content: row.content,
+    summary: row.summary,
+    type: row.type,
+    read: Boolean(row.read),
+    bookmarked: Boolean(row.bookmarked),
+    createdAt: new Date(row.createdAt),
+  };
+}
 
-async function readDb(): Promise<Notification[]> {
-  try {
-    const data = await fs.readFile(dbPath, 'utf-8');
-    const db = JSON.parse(data);
-    // Dates are stored as strings in JSON, so we need to convert them back
-    return db.notifications.map((n: any) => ({
-      ...n,
-      createdAt: new Date(n.createdAt),
-    }));
-  } catch (error) {
-    // If the file doesn't exist, it's the first run.
-    // Let's initialize with the default data.
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      console.log("Database file not found, creating with initial data...");
-      await writeDb(initialNotifications);
-      return initialNotifications;
+function seedIfEmpty() {
+  const insert = db.prepare(`INSERT OR IGNORE INTO notifications (id, headline, content, summary, type, read, bookmarked, createdAt) VALUES (@id, @headline, @content, @summary, @type, @read, @bookmarked, @createdAt)`);
+  const insertMany = db.transaction((items: Notification[]) => {
+    for (const n of items) {
+      insert.run({
+        id: n.id,
+        headline: n.headline,
+        content: n.content,
+        summary: n.summary,
+        type: n.type,
+        read: n.read ? 1 : 0,
+        bookmarked: n.bookmarked ? 1 : 0,
+        createdAt: n.createdAt.getTime(),
+      });
     }
-    console.error("Error reading database file:", error);
-    return initialNotifications;
-  }
+  });
+  insertMany(initialNotifications);
 }
 
-async function writeDb(data: Notification[]) {
-  try {
-    await fs.writeFile(dbPath, JSON.stringify({ notifications: data }, null, 2), 'utf-8');
-    console.log("Database updated successfully");
-  } catch (error) {
-    console.error("Error writing to database file:", error);
-  }
-}
-
-async function ensureInitialized() {
-  if (!isInitialized) {
-    try {
-      console.log("Initializing database...");
-      notifications = await readDb();
-      console.log(`Loaded ${notifications.length} notifications from database`);
-    } catch (error) {
-      console.error("Failed to initialize database:", error);
-      notifications = [...initialNotifications];
-    }
-    isInitialized = true;
-  }
-}
+seedIfEmpty();
 
 export async function getNotifications(): Promise<Notification[]> {
-  await ensureInitialized();
-  return notifications.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  const rows = db.prepare('SELECT * FROM notifications ORDER BY createdAt DESC').all();
+  return rows.map(rowToNotification);
 }
 
 export async function getNotificationById(id: string): Promise<Notification | undefined> {
-  await ensureInitialized();
-  return notifications.find((n) => n.id === id);
+  const row = db.prepare('SELECT * FROM notifications WHERE id = ?').get(id);
+  return row ? rowToNotification(row) : undefined;
 }
 
 export async function addNotification(data: Omit<Notification, "id" | "read" | "createdAt" | "bookmarked">): Promise<Notification> {
-  await ensureInitialized();
   const newNotification: Notification = {
     ...data,
     id: randomUUID(),
@@ -107,27 +106,36 @@ export async function addNotification(data: Omit<Notification, "id" | "read" | "
     bookmarked: false,
     createdAt: new Date(),
   };
-  notifications.push(newNotification);
-  await writeDb(notifications);
+  db.prepare(`INSERT INTO notifications (id, headline, content, summary, type, read, bookmarked, createdAt) VALUES (@id, @headline, @content, @summary, @type, 0, 0, @createdAt)`).run({
+    id: newNotification.id,
+    headline: newNotification.headline,
+    content: newNotification.content,
+    summary: newNotification.summary,
+    type: newNotification.type,
+    createdAt: newNotification.createdAt.getTime(),
+  });
   return newNotification;
 }
 
 export async function updateNotification(id: string, data: Partial<Notification>): Promise<Notification | undefined> {
-  await ensureInitialized();
-  const index = notifications.findIndex((n) => n.id === id);
-  if (index === -1) return undefined;
-  notifications[index] = { ...notifications[index], ...data };
-  await writeDb(notifications);
-  return notifications[index];
+  const existing = await getNotificationById(id);
+  if (!existing) return undefined;
+  const updated = { ...existing, ...data };
+  db.prepare(`UPDATE notifications SET headline=@headline, content=@content, summary=@summary, type=@type, read=@read, bookmarked=@bookmarked, createdAt=@createdAt WHERE id=@id`).run({
+    id: updated.id,
+    headline: updated.headline,
+    content: updated.content,
+    summary: updated.summary,
+    type: updated.type,
+    read: updated.read ? 1 : 0,
+    bookmarked: updated.bookmarked ? 1 : 0,
+    createdAt: updated.createdAt.getTime(),
+  });
+  return updated;
 }
 
 export async function deleteNotification(id: string): Promise<boolean> {
-  await ensureInitialized();
-  const initialLength = notifications.length;
-  notifications = notifications.filter((n) => n.id !== id);
-  const success = notifications.length < initialLength;
-  if (success) {
-    await writeDb(notifications);
-  }
-  return success;
+  const result = db.prepare('DELETE FROM notifications WHERE id = ?').run(id);
+  return result.changes > 0;
 }
+


### PR DESCRIPTION
## Summary
- switch notification storage from JSON files to SQLite
- add `better-sqlite3` and typings
- ignore generated SQLite database
- expose REST API endpoints for listing, updating and deleting notifications
- document API usage in README

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685941c96d5483238f88e4d0db515f18